### PR TITLE
docs(readme): add a section for different package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,21 @@ NeoVim 0.5 or newer
 
 ## Installation
 
-First add this plugin using your plugin manager of choice. For example, using
-vim-plug:
+First add this plugin using your plugin manager of choice.
+
+### lazy.nvim
+
+```lua
+{
+  "yorickpeterse/nvim-window",
+  keys = {
+    { "<leader>wj", "<cmd>lua require('nvim-window').pick()<cr>", desc = "nvim-window: Jump to window" },
+  },
+  config = true,
+}
+```
+
+### vim-plug
 
 ```vim
 Plug 'https://gitlab.com/yorickpeterse/nvim-window.git'


### PR DESCRIPTION
## What

Breaks out installation steps into sections that are by package manager and adds lazy.nvim section.

## Why

To help simplify onboarding of new users that use a variety of plugin managers.