### PR TITLE
add option to force uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ require('nvim-window').setup({
 
   -- The border style to use for the floating window.
   border = 'single'
+
+  -- convert all chars to uppercase
+  -- removes need to press shift to select uppercase hint char
+  -- default is `nil`
+  only_uppercase = true
 })
 ```
 
@@ -135,6 +140,7 @@ require('nvim-window').setup({
   normal_hl = 'BlackOnLightYellow',
   hint_hl = 'Bold',
   border = 'none'
+
 })
 ```
 

--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -53,6 +53,9 @@ local config = {
 
   -- The border style to use for the floating window.
   border = 'single',
+
+  -- converts all alphabetic hint characters and user input to uppercase
+  -- user doesn't have to hold down shift to select the uppercase hint characters
   only_uppercase = nil
 }
 

--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -53,6 +53,7 @@ local config = {
 
   -- The border style to use for the floating window.
   border = 'single',
+  only_uppercase = nil
 }
 
 -- Returns a table that maps the hint keys to their corresponding windows.
@@ -170,12 +171,42 @@ end
 local function get_char()
   local ok, char = pcall(fn.getchar)
 
-  return ok and fn.nr2char(char) or nil
+  if not ok then
+    return nil
+  end
+
+  if config.only_uppercase then
+    return fn.nr2char(char):gsub("%a", string.upper)
+  end
+
+  return fn.nr2char(char)
+end
+
+local function capitalizeAllCharsAndRemoveDuplicates(strings)
+  local tempTable = {}
+  local result = {}
+
+  for _, str in ipairs(strings) do
+    -- Capitalize each alphabetic character in the string
+    local capitalizedStr = str:gsub("%a", string.upper)
+
+    -- If the capitalized string hasn't been encountered yet, add it to the result
+    if not tempTable[capitalizedStr] then
+      table.insert(result, capitalizedStr)
+      tempTable[capitalizedStr] = true
+    end
+  end
+
+  return result
 end
 
 -- Configures the plugin by merging the given settings into the default ones.
 function M.setup(user_config)
   config = vim.tbl_extend('force', config, user_config)
+
+  if config.only_uppercase then
+    config.chars = capitalizeAllCharsAndRemoveDuplicates(config.chars)
+  end
 end
 
 -- Picks a window to jump to, and makes it the active window.


### PR DESCRIPTION
with the plugin as it is now, to select uppercase hint characters, the user has to actually press shift or turn on caps lock to select them.  the changes here add an option to the config that

1) converts all lowercase hint characters to uppercase
2) automatically converts keyboard input to select a window to uppercase so the user doesn't have to press shift 