### PR TITLE
fix: Fix detecting container windows.

### DIFF
--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -225,7 +225,7 @@ end
 function M.pick()
   local to_remove = {}
   local windows = {}
-  for id in api.nvim_tabpage_list_wins(0) do
+  for _, id in pairs(api.nvim_tabpage_list_wins(0)) do
     local conf = api.nvim_win_get_config(id)
     if conf.relative == '' then
       table.insert(windows, id)

--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -223,24 +223,20 @@ end
 
 -- Picks a window to jump to, and makes it the active window.
 function M.pick()
-    local to_remove = {}
-  local windows = vim.tbl_filter(function(id)
+  local to_remove = {}
+  local windows = {}
+  for id in api.nvim_tabpage_list_wins(0) do
     local conf = api.nvim_win_get_config(id)
     if conf.relative == '' then
-      return true
+      table.insert(windows, id)
+    elseif conf.relative == 'win' and conf.focusable then
+      to_remove[id] = true
     end
-    if conf.relative == 'win' and conf.focusable then
-      table.insert(to_remove, conf.win)
-      return true
-    end
-    return false
-  end, api.nvim_tabpage_list_wins(0))
+  end
 
-  for _, id in pairs(to_remove) do
-    for idx, win_id in pairs(windows) do
-      if win_id == id then
-        table.remove(windows, idx)
-      end
+  for idx, win_id in pairs(windows) do
+    if to_remove[win_id] then
+      table.remove(windows, idx)
     end
   end
 

--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -223,9 +223,26 @@ end
 
 -- Picks a window to jump to, and makes it the active window.
 function M.pick()
+    local to_remove = {}
   local windows = vim.tbl_filter(function(id)
-    return api.nvim_win_get_config(id).relative == ''
+    local conf = api.nvim_win_get_config(id)
+    if conf.relative == '' then
+      return true
+    end
+    if conf.relative == 'win' and conf.focusable then
+      table.insert(to_remove, conf.win)
+      return true
+    end
+    return false
   end, api.nvim_tabpage_list_wins(0))
+
+  for _, id in pairs(to_remove) do
+    for idx, win_id in pairs(windows) do
+      if win_id == id then
+        table.remove(windows, idx)
+      end
+    end
+  end
 
   local window_keys = window_keys(windows)
   local hints_state = show_hints(window_keys, true)

--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -229,8 +229,10 @@ function M.pick()
     local conf = api.nvim_win_get_config(id)
     if conf.relative == '' then
       table.insert(windows, id)
-    elseif conf.relative == 'win' and conf.focusable then
-      to_remove[id] = true
+    end
+    if conf.relative == 'win' and conf.focusable then
+      table.insert(windows, id)
+      to_remove[conf.win] = true
     end
   end
 


### PR DESCRIPTION
Currently `nvim-window` is only checking if the window is `relative` or not.

However, there can be windows which are (a) focusable, and (b) relative set to `win`. In these cases, the id in the conf table available in the `win` key is actually a container, and this relative window is the focusable one.

This PR takes that into consideration and detect the focusable windows currectly.