### PR TITLE
a fix for escape variable value and add a new feature

### DIFF
--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -396,10 +396,10 @@ function M.pick()
   local hints_state = show_hints(win_keys, true)
   local window = get_selected_winid(hints_state, win_keys)
 
+  hide_hints(hints_state, true)
   if window then
     api.nvim_set_current_win(window)
   end
-  hide_hints(hints_state, true)
 end
 
 return M


### PR DESCRIPTION
1. I changed the value of escape variable, because in lua, 27 is only a number not equal to character '<ESC>'. That is different from C. So I use the function vim.fn.nr2char(27) to fix it.
2. I add a new function based on your windows selection. It is to move in another window without changing your current window and position in original window. I name it as M.other(). I add map named config.motions_map for motions map in the mode. I also add config.motions_leader for user to uses more than one characters or trigger theirs functions in the mode.
3. I get two functions from your M.pick() and rewrite it with the two functions. Of course I use the two functions in M.other(), too.

I present a gif to show it.
![record](https://github.com/user-attachments/assets/62c6881e-513b-4be7-91d0-e0d95d9cfc7f)
