### PR TITLE
Separates picking a window and setting is as active

### DIFF
--- a/lua/nvim-window.lua
+++ b/lua/nvim-window.lua
@@ -216,8 +216,8 @@ function M.setup(user_config)
   config = vim.tbl_extend('force', config, user_config)
 end
 
--- Picks a window to jump to, and makes it the active window.
-function M.pick()
+---@return number? winr of the chosen window, or nil if not chosen
+function M.pick_window()
   local windows = {}
 
   for _, id in ipairs(api.nvim_tabpage_list_wins(0)) do
@@ -268,6 +268,12 @@ function M.pick()
 
   hide_hints(hints_state, true)
 
+  return window
+end
+
+-- Picks a window to jump to, and makes it the active window.
+function M.pick()
+  local window = M.pick_window()
   if window then
     api.nvim_set_current_win(window)
   end


### PR DESCRIPTION
This change allows reusing window picking logic for other purposes.

My use case is in knowing the full path to the file opened in another window

```lua
vim.keymap.set({ 'n', 'x', 'o' }, '<leader>ff', function()
    local window = nvim_window.pick_window()
    if window ~= nil then
        local bufnr = vim.api.nvim_win_get_buf(window)
        utils.show_full_file_path(bufnr)
    end
end, {})
```